### PR TITLE
Remove leading space char on 2 lines of ASFMinifiedLicenseHeader.txt.

### DIFF
--- a/scancode/ASFMinifiedLicenseHeader.txt
+++ b/scancode/ASFMinifiedLicenseHeader.txt
@@ -1,2 +1,2 @@
- // Licensed to the Apache Software Foundation (ASF) under one or more contributor
- // license agreements; and to You under the Apache License, Version 2.0.
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.


### PR DESCRIPTION
The baseline mini header had a single leading char of its 2 lines; this was not intended.