### PR TITLE
WIP: Create/enable Travis CI in root of util. repo. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ python:
 # command to install dependencies
 # install: "pip install -r requirements.txt"
 # command to run tests
-script: ./test.sh
+
+# Invoke ScanCode tests
+script: ./scancode/test.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+[![Build Status](https://travis-ci.org/apache/incubator-openwhisk-utilities.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-utilities)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+
 # OpenWhisk Utilities
 
 Shared utilities used across Apache OpenWhisk project repositories.
@@ -12,5 +16,5 @@ The following utilities are included in this repository (by subdirectory):
 
 Report bugs, ask questions and request features [here on GitHub](../../issues).
 
-You can also join our slack channel and chat with developers. To get access to our slack channel, 
+You can also join our slack channel and chat with developers. To get access to our slack channel,
 request an invite [here](http://slack.openwhisk.org).

--- a/scancode/ASFLicenseHeaderLua.txt
+++ b/scancode/ASFLicenseHeaderLua.txt
@@ -1,0 +1,16 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--

--- a/scancode/scanCode.cfg
+++ b/scancode/scanCode.cfg
@@ -6,6 +6,7 @@
 [Licenses]
 ASFLicenseHeader.txt
 ASFMinifiedLicenseHeader.txt
+ASFLicenseHeaderLua.txt
 ApacheIBMLicenseHeader.txt
 
 # Filters (path/filename) with wildcards and associated scan checks
@@ -20,6 +21,7 @@ ApacheIBMLicenseHeader.txt
 *.gradle=no_tabs, no_trailing_spaces, eol_at_eof
 *.md=no_tabs, eol_at_eof
 *.go=has_block_license, no_tabs, no_trailing_spaces, eol_at_eof
+*.lua=has_block_license
 build.xml=no_tabs, no_trailing_spaces, eol_at_eof
 deploy.xml=no_tabs, no_trailing_spaces, eol_at_eof
 

--- a/scancode/tests/good/good-hello.lua
+++ b/scancode/tests/good/good-hello.lua
@@ -1,0 +1,19 @@
+#!/usr/bin/lua
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+print ("Hello World!")

--- a/scancode/tests/mixed/bad-hello.lua
+++ b/scancode/tests/mixed/bad-hello.lua
@@ -1,0 +1,6 @@
+#!/usr/bin/lua
+--
+-- Hello world
+--
+
+print ("Hello World!")

--- a/scancode/travis.cfg
+++ b/scancode/travis.cfg
@@ -5,6 +5,8 @@
 # resides.
 [Licenses]
 ASFLicenseHeader.txt
+ASFMinifiedLicenseHeader.txt
+ASFLicenseHeaderLua.txt
 
 # Filters (path/filename) with wildcards and associated scan checks
 # that are to be run against them.  The checks are actual valid
@@ -18,6 +20,7 @@ ASFLicenseHeader.txt
 *.gradle=no_tabs, no_trailing_spaces, eol_at_eof
 *.md=no_tabs, eol_at_eof
 *.go=has_block_license, no_tabs, no_trailing_spaces, eol_at_eof
+*.lua=has_block_license
 build.xml=no_tabs, no_trailing_spaces, eol_at_eof
 deploy.xml=no_tabs, no_trailing_spaces, eol_at_eof
 
@@ -30,7 +33,6 @@ tests/bad
 tests/mixed
 tests/MixedCase
 tests/exclude
-
 
 [Options]
 # Not all code files allow licenses to appear starting at the first character


### PR DESCRIPTION
Currently, Travis config is in scancode subdir. and is not being picked up; it needs to be moved to repo. root so travis will actually be run.