### PR TITLE
Add vendor directory to scancode exclusions

### DIFF
--- a/scancode/scanCode.cfg
+++ b/scancode/scanCode.cfg
@@ -36,6 +36,9 @@ deploy.xml=no_tabs, no_trailing_spaces, eol_at_eof
 # OpenWhisk binary artifact exclusion
 bin
 
+# 'vendor' directory create by go build tools (e.g. 'gogradle')
+vendor
+
 # Jenkins/test generated reports
 tests/build/reports
 


### PR DESCRIPTION
As part of the work I'm doing to compile the OpenWhisk CLI using Gradle and the 'gogradle' package, it's necessary to exclude the 'vendor' directory from codescanning, as the directory is used to hold downloaded dependencies and is excluded from git code control.