### PR TITLE
Add '.gogradle' directory to exclusions

### DIFF
--- a/scancode/scanCode.cfg
+++ b/scancode/scanCode.cfg
@@ -36,7 +36,8 @@ deploy.xml=no_tabs, no_trailing_spaces, eol_at_eof
 # OpenWhisk binary artifact exclusion
 bin
 
-# 'vendor' directory create by go build tools (e.g. 'gogradle')
+# 'vendor' and cache directory create by gograble build tool
+.gogradle
 vendor
 
 # Jenkins/test generated reports


### PR DESCRIPTION
Hi all,

As I continue to work on rationalizing the CLI build, I found another case where the scancode tool was delivering a positive on downloaded (cached) code.  To that end, I've added the '.gogradle' cache directory created by the gogradle build tools to the exclusion list for scancode.

Cheers,
-J