### PR TITLE
Include wrk tests in scancode checks

### DIFF
--- a/scancode/ASF-Release.cfg
+++ b/scancode/ASF-Release.cfg
@@ -69,10 +69,9 @@ vendor
 
 # Exclude from incubator-openwhisk
 # Jenkins/test generated reports
-# Test data. Performance (post.lua) and Empty (empty.js)
+# Test data.
 # Generated binary artifacts
 tests/build/reports
-tests/performance/wrk_tests
 tests/dat/actions
 docs/images
 bin


### PR DESCRIPTION
Re-includes the wrk test directory after having added the correct license header to post.lua