### PR TITLE
remove MinifiedHeaders from ASF-Release.cfg

### DIFF
--- a/scancode/ASF-Release.cfg
+++ b/scancode/ASF-Release.cfg
@@ -11,9 +11,6 @@ ASFLicenseHeader.txt
 ASFLicenseHeaderBash.txt
 ASFLicenseHeaderHash.txt
 ASFLicenseHeaderLua.txt
-ASFMinifiedLicenseHashHeader.txt
-ASFMinifiedLicenseHeader.txt
-ASFMinifiedLicenseHeaderREM.txt
 
 # Filters (path/filename) with wildcards and associated scan checks
 # that are to be run against them.  The checks are actual valid


### PR DESCRIPTION
We agreed to eliminate the use of minified headers from the project
header conventions.  Most (all?) repos have been updated accordingly.
Therefore start enforcing the stricter rules in scancode.